### PR TITLE
Clean Up - Card Pages

### DIFF
--- a/src/components/button/BackButton.vue
+++ b/src/components/button/BackButton.vue
@@ -5,16 +5,12 @@ const router = useRouter();
 const route = useRoute();
 const goBack = () => {
   if (window.history.state?.back) {
-    return router.back();
+    const urlPaths = route.path.split('/').filter(Boolean);
+    if (urlPaths.length === 1) {
+      return router.push('/');
+    }
   }
-
-  const urlPaths = route.path.split('/').filter(Boolean);
-  if (urlPaths.length > 1) {
-    urlPaths.pop();
-    const fallBackPath = '/' + urlPaths.join('/');
-    return router.push(fallBackPath);
-  }
-  return router.push('/');
+  return router.back();
 };
 </script>
 

--- a/src/pages/cards/DamageFearWeakCardList.vue
+++ b/src/pages/cards/DamageFearWeakCardList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useDamageFearCardStore } from '/src/stores/damageFearCardStore.js';
@@ -9,24 +9,18 @@ import BackButton from 'src/components/button/BackButton.vue';
 const route = useRoute();
 const damageFearCardStore = useDamageFearCardStore();
 const weaknessCardStore = useWeaknessCardStore();
-const { loading: loadingDmgFear } = storeToRefs(damageFearCardStore);
-const { loading: loadingWeakness } = storeToRefs(weaknessCardStore);
-
-
-onBeforeMount(() => {
-  damageFearCardStore.fetchDamageFearCards();
-  weaknessCardStore.fetchWeaknessCards();
-});
+const { loading: loadingDmgFear, damageCards, fearCards } = storeToRefs(damageFearCardStore);
+const { loading: loadingWeakness, weaknessCards } = storeToRefs(weaknessCardStore);
 
 const cards = computed(() => {
   if (route.path.includes('/damage')) {
-    return damageFearCardStore.getDamageCards;
+    return damageCards.value;
   }
   if (route.path.includes('/fear')) {
-    return damageFearCardStore.getFearCards;
+    return fearCards.value;
   }
   if (route.path.includes('/weakness')) {
-    return weaknessCardStore.getWeaknessCards;
+    return weaknessCards.value;
   }
   return [];
 });

--- a/src/pages/cards/EquipmentList.vue
+++ b/src/pages/cards/EquipmentList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useEquipmentStore } from '/src/stores/equipmentStore.js';
@@ -9,10 +9,6 @@ const route = useRoute();
 const typeParam = route.params.type;
 const equipStore = useEquipmentStore();
 const { loading } = storeToRefs(equipStore);
-
-onBeforeMount(() => {
-  equipStore.fetchEquipCards();
-});
 
 const equipList = computed(() => {
   return equipStore.getEquipmentListByType(typeParam);
@@ -25,7 +21,7 @@ const equipList = computed(() => {
     <div v-if="loading" class="row justify-center">
       <q-spinner-oval color="primary" size="10rem" />
     </div>
-    
+
     <q-card
       v-else
       v-for="equip in equipList"

--- a/src/pages/cards/EquipmentTypeList.vue
+++ b/src/pages/cards/EquipmentTypeList.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRouter } from 'vue-router';
 import { useEquipmentStore } from '/src/stores/equipmentStore.js';
@@ -7,15 +6,7 @@ import BackButton from 'components/button/BackButton.vue';
 
 const router = useRouter();
 const equipStore = useEquipmentStore();
-const { loading } = storeToRefs(equipStore);
-
-onBeforeMount(() => {
-  equipStore.fetchEquipCards();
-});
-
-const equipTypes = computed(() => {
-  return equipStore.getEquipmentTypes;
-});
+const { loading, equipTypes } = storeToRefs(equipStore);
 
 const goToType = (type) => {
   router.push('/cards/equipment/' + type);
@@ -28,7 +19,7 @@ const goToType = (type) => {
     <div v-if="loading" class="row justify-center">
       <q-spinner-oval color="primary" size="10rem" />
     </div>
-    
+
     <div v-else class="q-gutter-sm">
       <q-card
         v-for="type in equipTypes"

--- a/src/pages/cards/HeroList.vue
+++ b/src/pages/cards/HeroList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeMount, ref } from 'vue';
+import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useHeroDetailStore } from '/src/stores/heroDetailStore.js';
 import BackButton from 'src/components/button/BackButton.vue';
@@ -7,17 +7,9 @@ import HeroDetailCard from 'components/cards/HeroDetailCard.vue';
 import HeroDetails from 'components/dialog/HeroDetails.vue';
 
 const heroDetailStore = useHeroDetailStore();
-const { loading } = storeToRefs(heroDetailStore);
+const { loading, heroes } = storeToRefs(heroDetailStore);
 const selectedHero = ref({});
 const showHeroDetails = ref(false);
-
-onBeforeMount(() => {
-  heroDetailStore.fetchHeroDetails();
-});
-
-const heroList = computed(() => {
-  return heroDetailStore.getAllHeroDetails;
-});
 
 const openHeroDetails = (hero) => {
   showHeroDetails.value = true;
@@ -35,7 +27,7 @@ const openHeroDetails = (hero) => {
 
     <hero-detail-card
       v-else
-      v-for="hero in heroList"
+      v-for="hero in heroes"
       :key="hero.id"
       :hero="hero"
       @open-hero-details="openHeroDetails"

--- a/src/pages/cards/InfoTypeList.vue
+++ b/src/pages/cards/InfoTypeList.vue
@@ -1,19 +1,12 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
+import { storeToRefs } from 'pinia';
 import { useRouter } from 'vue-router';
 import { useInfoCardStore } from 'stores/infoCardStore.js';
 import BackButton from 'src/components/button/BackButton.vue';
 
 const router = useRouter();
 const infoCardStore = useInfoCardStore();
-
-onBeforeMount(() => {
-  infoCardStore.fetchInfoCards();
-});
-
-const infoTypes = computed(() => {
-  return infoCardStore.getInfoTypes;
-});
+const { loading, infoTypes } = storeToRefs(infoCardStore);
 
 const goToCardList = (type) => {
   router.push('/cards/info/' + type);
@@ -23,7 +16,11 @@ const goToCardList = (type) => {
 <template>
   <back-button />
   <div class="q-pa-md">
-    <div class="q-gutter-sm">
+    <div v-if="loading" class="row justify-center">
+      <q-spinner-oval color="primary" size="10rem" />
+    </div>
+
+    <div v-else class="q-gutter-sm">
       <q-card
         v-for="type in infoTypes"
         :key="type"

--- a/src/pages/cards/RoleCardList.vue
+++ b/src/pages/cards/RoleCardList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted } from 'vue';
+import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useRoleCardStore } from '/src/stores/roleCardStore.js';
@@ -9,10 +9,6 @@ const route = useRoute();
 const roleType = route.params.role;
 const roleCardStore = useRoleCardStore();
 const { loading } = storeToRefs(roleCardStore);
-
-onMounted(() => {
-  roleCardStore.fetchRoleCards();
-});
 
 const roleCards = computed(() => {
   return roleCardStore.getRoleCardsByType(roleType);

--- a/src/pages/cards/RoleTypeList.vue
+++ b/src/pages/cards/RoleTypeList.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRouter } from 'vue-router';
 import { useRoleCardStore } from '/src/stores/roleCardStore.js';
@@ -8,15 +7,7 @@ import BackButton from 'src/components/button/BackButton.vue';
 
 const router = useRouter();
 const roleCardStore = useRoleCardStore();
-const { loading } = storeToRefs(roleCardStore);
-
-onBeforeMount(() => {
-  roleCardStore.fetchRoleCards();
-});
-
-const roleList = computed(() => {
-  return roleCardStore.getRoles;
-});
+const { loading, roles } = storeToRefs(roleCardStore);
 
 const goToRoleList = (role) => {
   router.push('/cards/roles/' + role);
@@ -32,7 +23,7 @@ const goToRoleList = (role) => {
 
     <div v-else class="q-gutter-sm">
       <q-card
-        v-for="role in roleList"
+        v-for="role in roles"
         :key="role"
         @click="goToRoleList(role)"
         class="cursor-pointer hoverable"

--- a/src/pages/cards/TitleCardList.vue
+++ b/src/pages/cards/TitleCardList.vue
@@ -1,20 +1,11 @@
 <script setup>
-import { computed, onBeforeMount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useTitleCardStore } from '/src/stores/titleCardStore.js';
 import BackButton from 'src/components/button/BackButton.vue';
 import FilterButton from 'components/button/FilterButton.vue';
 
 const titleCardStore = useTitleCardStore();
-const { loading } = storeToRefs(titleCardStore);
-
-onBeforeMount(() => {
-  titleCardStore.fetchTitleCards();
-});
-
-const titleCards = computed(() => {
-  return titleCardStore.getTitleCards;
-});
+const { loading, titleCards } = storeToRefs(titleCardStore);
 
 </script>
 

--- a/src/stores/damageFearCardStore.js
+++ b/src/stores/damageFearCardStore.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useDamageFearCardStore = defineStore('damageFearCardStore', () => {
@@ -29,18 +29,11 @@ export const useDamageFearCardStore = defineStore('damageFearCardStore', () => {
     }
   };
 
-  const getDamageCards = computed(() => {
-    return damageCards.value;
-  });
-  const getFearCards = computed(() => {
-    return fearCards.value;
-  });
-
   return {
     error,
-    fetchDamageFearCards,
-    getDamageCards,
-    getFearCards,
-    loading
+    loading,
+    damageCards,
+    fearCards,
+    fetchDamageFearCards
   };
 });

--- a/src/stores/equipmentStore.js
+++ b/src/stores/equipmentStore.js
@@ -1,16 +1,16 @@
 import axios from 'axios';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useEquipmentStore = defineStore('equipmentStore', () => {
   const url = '/data/equipCards.json';
   const loading = ref(false);
   const error = ref(null);
-  const equipList = ref({});
+  const equipmentMap = ref({});
   const equipTypes = ref([]);
 
   const fetchEquipCards = async () => {
-    const hasData = Object.keys(equipList.value).length && equipTypes.value.length;
+    const hasData = Object.keys(equipmentMap.value).length && equipTypes.value.length;
     if (hasData) {
       return;
     }
@@ -19,7 +19,7 @@ export const useEquipmentStore = defineStore('equipmentStore', () => {
     try {
       const response = await axios.get(url);
       const data = response.data;
-      equipList.value = data;
+      equipmentMap.value = data;
       equipTypes.value = Object.keys(data);
     }
     catch (error) {
@@ -30,19 +30,16 @@ export const useEquipmentStore = defineStore('equipmentStore', () => {
     }
   };
 
-  const getEquipmentTypes = computed(() => {
-    return equipTypes.value;
-  });
-
   const getEquipmentListByType = (type) => {
-    return equipList.value[type];
+    return equipmentMap.value[type];
   };
 
   return {
     error,
+    loading,
+    equipmentMap,
+    equipTypes,
     fetchEquipCards,
-    getEquipmentTypes,
-    getEquipmentListByType,
-    loading
+    getEquipmentListByType
   };
 });

--- a/src/stores/heroDetailStore.js
+++ b/src/stores/heroDetailStore.js
@@ -6,11 +6,11 @@ export const useHeroDetailStore = defineStore('heroDetailStore', () => {
   const url = '/data/heroDetails.json';
   const loading = ref(false);
   const error = ref(null);
-  const heroDetails = ref({});
+  const heroes = ref({});
   const heroNames = ref([]);
 
   const fetchHeroDetails = async () => {
-    const hasData = Object.keys(heroDetails.value).length && heroNames.value.length;
+    const hasData = Object.keys(heroes.value).length && heroNames.value.length;
     if (hasData) {
       return;
     }
@@ -19,7 +19,7 @@ export const useHeroDetailStore = defineStore('heroDetailStore', () => {
     try {
       const response = await axios.get(url);
       const data = response.data;
-      heroDetails.value = data;
+      heroes.value = data;
       heroNames.value = Object.keys(data);
     }
     catch (error) {
@@ -30,18 +30,26 @@ export const useHeroDetailStore = defineStore('heroDetailStore', () => {
     }
   };
 
-  const getAllHeroDetails = computed(() => {
-    return heroDetails.value;
-  });
+  const getHeroByName = (name) => {
+    const heroesArray = Object.values(heroes.value);
+    const hero = heroesArray.find(hero => hero.name === name);
+    return hero ? hero : null;
+  };
 
-  const getHeroNames = computed(() => {
-    return heroNames.value;
-  });
+  const getHeroCardsByHeroId = (id) => {
+    const heroesArray = Object.values(heroes.value);
+    const hero = heroesArray.find(hero => hero.id === id);
+    return hero ? hero.cards : null;
+  };
 
-  // List of objects for q-select dropdown
+  /**
+   * Method to create Hero objects formatted for q-select dropdown.
+   *
+   * @returns An array of objects with keys: label (hero.name) and value (hero.id)
+   */
   const getHeroOptions = computed(() => {
     const options = [];
-    for (const hero of Object.values(heroDetails.value)) {
+    for (const hero of Object.values(heroes.value)) {
       options.push({
         label: hero.name,
         value: hero.id,
@@ -50,32 +58,14 @@ export const useHeroDetailStore = defineStore('heroDetailStore', () => {
     return options;
   });
 
-  const getHeroCardsByHeroId = (id) => {
-    for (const hero of Object.values(heroDetails.value)) {
-      if (hero.id === id) {
-        return hero.cards;
-      }
-    }
-    return null;
-  };
-
-  const getHeroByName = (name) => {
-    for (const hero in heroDetails.value) {
-      if (heroDetails.value[hero].name === name) {
-        return  heroDetails.value[hero];
-      }
-    }
-    return error.value = 'No hero found...';
-  };
-
   return {
     error,
+    loading,
+    heroes,
+    heroNames,
     fetchHeroDetails,
     getHeroByName,
-    getAllHeroDetails,
-    getHeroNames,
-    getHeroOptions,
     getHeroCardsByHeroId,
-    loading
+    getHeroOptions
   };
 });

--- a/src/stores/infoCardStore.js
+++ b/src/stores/infoCardStore.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useInfoCardStore = defineStore('infoCardStore', () => {
@@ -7,6 +7,7 @@ export const useInfoCardStore = defineStore('infoCardStore', () => {
   const loading = ref(false);
   const error = ref(null);
   const infoCards = ref({});
+  const infoTypes = ref([]);
 
   const fetchInfoCards = async () => {
     const hasData = Object.keys(infoCards.value).length;
@@ -17,7 +18,9 @@ export const useInfoCardStore = defineStore('infoCardStore', () => {
     loading.value = true;
     try {
       const response = await axios.get(url);
-      infoCards.value = response.data;
+      const data = response.data;
+      infoCards.value = data;
+      infoTypes.value = Object.keys(data);
     }
     catch (error) {
       error.value = error.message;
@@ -27,19 +30,15 @@ export const useInfoCardStore = defineStore('infoCardStore', () => {
     }
   };
 
-  const getInfoTypes = computed(() => {
-    return Object.keys(infoCards.value);
-  });
-
   const getInfoCardsByType = (type) => {
     return infoCards.value[type];
   };
 
   return {
     error,
+    loading,
+    infoTypes,
     fetchInfoCards,
-    getInfoTypes,
-    getInfoCardsByType,
-    loading
+    getInfoCardsByType
   };
 });

--- a/src/stores/roleCardStore.js
+++ b/src/stores/roleCardStore.js
@@ -7,11 +7,11 @@ export const useRoleCardStore = defineStore('roleCardStore', () => {
   const url = '/data/roleCards.json';
   const loading = ref(false);
   const error = ref(null);
-  const roleCards = ref({});
+  const roleCardsMap = ref({});
   const roles = ref([]);
 
   const fetchRoleCards = async () => {
-    const hasData = Object.keys(roleCards.value).length && roles.value.length;
+    const hasData = Object.keys(roleCardsMap.value).length && roles.value.length;
     if (hasData) {
       return;
     }
@@ -20,7 +20,7 @@ export const useRoleCardStore = defineStore('roleCardStore', () => {
     try {
       const response = await axios.get(url);
       const data = response.data;
-      roleCards.value = data;
+      roleCardsMap.value = data;
       roles.value = Object.keys(data);
     }
     catch (error) {
@@ -31,15 +31,15 @@ export const useRoleCardStore = defineStore('roleCardStore', () => {
     }
   };
 
-  const getRoles = computed(() => {
-    return roles.value;
-  });
-
   const getRoleCardsByType = (type) => {
-    return roleCards.value[type];
+    return roleCardsMap.value[type];
   };
 
-  // List of objects for q-select dropdown
+  /**
+   * Method to create Role objects formatted for q-select dropdown.
+   *
+   * @returns An array of objects with keys: label (role using camelCase) and value (role)
+   */
   const getRoleOptions = computed(() => {
     const options = [];
     for (const role of roles.value) {
@@ -53,10 +53,11 @@ export const useRoleCardStore = defineStore('roleCardStore', () => {
 
   return {
     error,
+    loading,
+    roleCardsMap,
+    roles,
     fetchRoleCards,
-    getRoles,
     getRoleCardsByType,
-    getRoleOptions,
-    loading
+    getRoleOptions
   };
 });

--- a/src/stores/titleCardStore.js
+++ b/src/stores/titleCardStore.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 
@@ -28,14 +28,10 @@ export const useTitleCardStore = defineStore('titleCardStore', () =>{
     }
   };
 
-  const getTitleCards = computed(() => {
-    return titleCards.value;
-  });
-
   return {
     error,
-    fetchTitleCards,
-    getTitleCards,
-    loading
+    loading,
+    titleCards,
+    fetchTitleCards
   };
 });

--- a/src/stores/weaknessCardStore.js
+++ b/src/stores/weaknessCardStore.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useWeaknessCardStore = defineStore('weaknessStore', () => {
@@ -27,14 +27,10 @@ export const useWeaknessCardStore = defineStore('weaknessStore', () => {
     }
   };
 
-  const getWeaknessCards = computed(() => {
-    return weaknessCards.value;
-  });
-
   return {
     error,
-    fetchWeaknessCards,
-    getWeaknessCards,
-    loading
+    loading,
+    weaknessCards,
+    fetchWeaknessCards
   };
 });


### PR DESCRIPTION
1. Made changes so that stores expose refs and corresponding pages/components related to cards use them instead of calling getters
2. also made changes to back button when browsing cards, no janky return to build-deck anymore (i think)